### PR TITLE
Switch to folder extensions, and a few updates to object-stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ Looking to learn about how Beaker works? Start here:
 |-|-|-|
 |[dat.json](https://github.com/datprotocol/dat.json)|The dat.json standard manifest file. Used to describe a dat.|April 20, 2018|
 
-## Deprecated
-
-|Spec|Description|Last&nbsp;Updated|
-|-|-|-|
-|[index.json](./index-json.md)|The index.json folder manifest file. Used to describe a folder.|Nov 2, 2018|
-
 ## Status badges
 
 ![Not written](https://img.shields.io/badge/Draft-Not%20written-red.svg)
@@ -57,3 +51,7 @@ Looking to learn about how Beaker works? Start here:
 ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
 ![Implemented](https://img.shields.io/badge/Status-Implemented-green.svg)
 
+## Deprecated
+
+ - [index.json](./index-json.md)
+ - [Record Protocols](https://github.com/beakerbrowser/record-protocols-spec)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Looking to learn about how Beaker works? Start here:
 ![Not written](https://img.shields.io/badge/Draft-Not%20written-red.svg)
 ![Draft](https://img.shields.io/badge/Draft-In%20progress-yellow.svg)
 ![Stable](https://img.shields.io/badge/Draft-Stable-green.svg)
-![Deprecated](https://img.shields.io/badge/Draft-Deprecated-ff69b4.svg)
+![Deprecated](https://img.shields.io/badge/Draft-Deprecated-lightgrey.svg)
 
 ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
 ![Implemented](https://img.shields.io/badge/Status-Implemented-green.svg)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Looking to learn about how Beaker works? Start here:
 |-|-|-|
 |[dat.json](https://github.com/datprotocol/dat.json)|The dat.json standard manifest file. Used to describe a dat.|April 20, 2018|
 
-### Deprecated
+## Deprecated
 
 |Spec|Description|Last&nbsp;Updated|
 |-|-|-|

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Looking to learn about how Beaker works? Start here:
  - **Manifest files and metadata**
    - [dat.json](https://github.com/datprotocol/dat.json). The dat.json standard manifest file. Used to describe a dat.
    - [Dat types](./dat-types.md). Standard dat "type" values and their effects in Beaker.
-   - [index.json](./index-json.md). The index.json folder manifest file. Used to describe a folder.
 
 ## Directory
 
@@ -31,11 +30,10 @@ Looking to learn about how Beaker works? Start here:
 
 |Spec|Description|Last&nbsp;Updated|
 |-|-|-|
-|[Beaker&nbsp;user&nbsp;filesystem](./beaker-user-fs.md)|The filesystem for users' personal information.|Nov 2, 2018|
-|[Beaker&nbsp;user&nbsp;identities](./beaker-identities.md)|APIs and UI flows for user identities.|Nov 2, 2018|
-|[index.json](./index-json.md)|The index.json folder manifest file. Used to describe a folder.|Nov 2, 2018|
+|[Beaker&nbsp;user&nbsp;filesystem](./beaker-user-fs.md)|The filesystem for users' personal information.|Nov 6, 2018|
+|[Beaker&nbsp;user&nbsp;identities](./beaker-identities.md)|APIs and UI flows for user identities.|Nov 6, 2018|
 |[Dat types](./dat-types.md)|Standard dat "type" values and their effects in Beaker.|Nov 2, 2018|
-|[Object-store&nbsp;folders](./object-store-folder.md)|Managed folders which help applications share data.|Nov 2, 2018|
+|[Object-store&nbsp;folders](./object-store-folder.md)|Managed folders which help applications share data.|Nov 6, 2018|
 
 ### Phase 2 - Stable
 
@@ -43,11 +41,18 @@ Looking to learn about how Beaker works? Start here:
 |-|-|-|
 |[dat.json](https://github.com/datprotocol/dat.json)|The dat.json standard manifest file. Used to describe a dat.|April 20, 2018|
 
+### Deprecated
+
+|Spec|Description|Last&nbsp;Updated|
+|-|-|-|
+|[index.json](./index-json.md)|The index.json folder manifest file. Used to describe a folder.|Nov 2, 2018|
+
 ## Status badges
 
 ![Not written](https://img.shields.io/badge/Draft-Not%20written-red.svg)
 ![Draft](https://img.shields.io/badge/Draft-In%20progress-yellow.svg)
 ![Stable](https://img.shields.io/badge/Draft-Stable-green.svg)
+![Deprecated](https://img.shields.io/badge/Draft-Deprecated-ff69b4.svg)
 
 ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
 ![Implemented](https://img.shields.io/badge/Status-Implemented-green.svg)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Looking to learn about how Beaker works? Start here:
 |Spec|Description|Last&nbsp;Updated|
 |-|-|-|
 |[Beaker&nbsp;user&nbsp;filesystem](./beaker-user-fs.md)|The filesystem for users' personal information.|Nov 6, 2018|
-|[Beaker&nbsp;user&nbsp;identities](./beaker-identities.md)|APIs and UI flows for user identities.|Nov 6, 2018|
-|[Dat types](./dat-types.md)|Standard dat "type" values and their effects in Beaker.|Nov 2, 2018|
+|[Beaker&nbsp;user&nbsp;identities](./beaker-identities.md)|APIs and UI flows for user identities.|Nov 2, 2018|
+|[Dat types](./dat-types.md)|Standard dat "type" values and their effects in Beaker.|Nov 6, 2018|
 |[Object-store&nbsp;folders](./object-store-folder.md)|Managed folders which help applications share data.|Nov 6, 2018|
 
 ### Phase 2 - Stable

--- a/beaker-user-fs.md
+++ b/beaker-user-fs.md
@@ -1,6 +1,6 @@
 # Beaker User Filesystem Spec
 
-**Last updated:** Nov 2, 2018
+**Last updated:** Nov 6, 2018
 
 ![Draft](https://img.shields.io/badge/Draft-In%20progress-yellow.svg) ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
 
@@ -15,13 +15,13 @@ The user filesystem is comprised of two dats called the "Private" and the "Publi
 The private dat is the root of the user's filesystem. It is kept off the network and can only be read by apps with permission. It is created with the `type` value of `["user-private-fs"]` and will have the following folder structure created automatically:
 
 ```
-data/     - private objectstore
-public/   - a mount of the public dat
+data.objs/     - private objectstore
+public/        - a mount of the public dat
 ```
 
 The filestructure has the following properties:
 
- - The `data/` folder is ["protected"](./index-json.md#type) and used by Beaker to contain [object-store folders](./object-store-folder.md).
+ - The `data.objs/` folder is a managed [object-store folder](./object-store-folder.md).
 
 ### Public dat
 
@@ -30,18 +30,14 @@ The public dat represents a public identity and contains information that the us
 The public dat is created with the `type` value of `["user-profile"]`. It will have the following folder structure created automatically:
 
 ```
-data/     - public objectstore
-keys/     - public keystore
+data.objs/     - public objectstore
+user.keys/     - public keystore
 ```
 
 The filestructure has the following properties:
 
- - The `data/` folder is ["protected"](./index-json.md#type) and used by Beaker to contain [object-store folders](./object-store-folder.md).
- - The `keys/` folder is ["protected"](./index-json.md#type) and used by Beaker to store cryptographic keys.
-
-### index.json file
-
-The `index.json` file is a metadata file used to describe each folder. See the [Index.json Spec](./index-json.md) for more information.
+ - The `data.objs/` folder is a managed [object-store folder](./object-store-folder.md).
+ - The `user.keys/` folder is a managed key-store folder.
 
 ### Permissions
 

--- a/dat-types.md
+++ b/dat-types.md
@@ -1,6 +1,6 @@
 # Dat Types Spec
 
-**Last updated:** Nov 2, 2018
+**Last updated:** Nov 6, 2018
 
 ![Draft](https://img.shields.io/badge/Draft-In%20progress-yellow.svg) ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
 
@@ -25,7 +25,7 @@ Beaker defines the following core dat types:
 
 The dat is a user's private filesystem. In addition to standard dat files (dat.json, favicon.ico) it contains the following standard files:
 
- - `data/` Contains a collection of [object-store folders](./object-store-folder.md).
+ - `data.objs/` A managed [object-store folder](./object-store-folder.md).
  - `public/` A mounted `user-profile` dat.
 
 See the [Beaker User Filesystem spec](./beaker-user-fs.md) for more information.
@@ -35,7 +35,8 @@ See the [Beaker User Filesystem spec](./beaker-user-fs.md) for more information.
 The dat is a public user identity. In addition to standard dat files (dat.json, favicon.ico) it contains the following standard files:
 
  - `thumbnail.(png|jpg|jpeg|gif)` A square image that represents the user (ideally 256x256).
- - `data/` Contains a collection of [object-store folders](./object-store-folder.md).
+ - `data.objs/` A managed [object-store folder](./object-store-folder.md).
+ - `user.keys/` A managed key-store folder.
 
 See the [Beaker User Filesystem spec](./beaker-user-fs.md) and the [Beaker Identities spec](./beaker-identities.md) for more information.
 

--- a/index-json.md
+++ b/index-json.md
@@ -2,9 +2,13 @@
 
 **Last updated:** Nov 2, 2018
 
-![Deprecated](https://img.shields.io/badge/Draft-Deprecated-ff69b4.svg) ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
+![Deprecated](https://img.shields.io/badge/Draft-Deprecated-lightgrey.svg) ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
+
+---
 
 *Deprecated, replaced by folder extensions. See [#13](https://github.com/beakerbrowser/specs/issues/13) and [#14](https://github.com/beakerbrowser/specs/issues/14) for discussion.*
+
+---
 
 A metadata file used to describe a folder.
 

--- a/index-json.md
+++ b/index-json.md
@@ -2,7 +2,9 @@
 
 **Last updated:** Nov 2, 2018
 
-![Draft](https://img.shields.io/badge/Draft-In%20progress-yellow.svg) ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
+![Deprecated](https://img.shields.io/badge/Draft-Deprecated-ff69b4.svg) ![Not implemented](https://img.shields.io/badge/Status-Not%20implemented-red.svg)
+
+*Deprecated, replaced by folder extensions. See [#13](https://github.com/beakerbrowser/specs/issues/13) and [#14](https://github.com/beakerbrowser/specs/issues/14) for discussion.*
 
 A metadata file used to describe a folder.
 


### PR DESCRIPTION
Closes #13 and #14 

Mike made a good point that the `index.json` could be more trouble than it's worth. This PR does the following things:

 - Deprecates `index.json`
 - Introduces the concept of a "folder extension"
 - Assigns the `.objs` extension to object-store folders
 - Assigns the `.keys` extension to key-store folders (which are not yet specced)
 - Restructures the object-store to use a custom `index.json`
 - Adds schema-url normalization

The new `index.json` in the `.objs` folder creates a directory for the various objects folders, which I realized is going to be pretty important for lookups. In the previous iteration, we would've had to scan the folders and check each of their metadata files.

Thanks @webdesserts !